### PR TITLE
disable tiered compilation for more performance

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :jvm-opts ^:replace ["-Xms1g" "-Xmx1g" "-server" "-XX:+AggressiveOpts" "-XX:+UseFastAccessorMethods"]
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.slf4j/slf4j-log4j12 "1.7.7"]
                  [clj-http "1.0.1"]


### PR DESCRIPTION
by default, leiningen sets the JVM up for startup time, via tiered
compilation (see https://github.com/technomancy/leiningen/wiki/Faster).

This doesn't play so well with getting the best performance, so when
aiming for performance you need to turn off tiered compilation. Also
nearly every production jvm runs with AggressiveOpts,
UseFastAccessorMethods, and -server, so enable them too.